### PR TITLE
{Ou,User}NavigationItem: distingish visually between user and ou

### DIFF
--- a/src/main/java/net/kemitix/ldapmanager/navigation/OuNavigationItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/OuNavigationItem.java
@@ -75,7 +75,7 @@ public final class OuNavigationItem extends AbstractNavigationItem {
 
     @Override
     public String toString() {
-        return ou.name();
+        return String.format("[%s]", ou.name());
     }
 
     @Override

--- a/src/main/java/net/kemitix/ldapmanager/navigation/UserNavigationItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/UserNavigationItem.java
@@ -75,7 +75,7 @@ public final class UserNavigationItem extends AbstractNavigationItem {
 
     @Override
     public String toString() {
-        return user.name();
+        return String.format(" %s ", user.name());
     }
 
     @Override

--- a/src/main/java/net/kemitix/ldapmanager/navigation/ui/DefaultNavigationItemActionListBox.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/ui/DefaultNavigationItemActionListBox.java
@@ -176,8 +176,7 @@ class DefaultNavigationItemActionListBox
         log.log(Level.FINEST, "findItemPositionByName(%s)", name);
         int selected = 0;
         for (final NavigationItem navigationItem : getItems()) {
-            final String itemName = navigationItem.toString();
-            if (name.equals(itemName)) {
+            if (name.equals(navigationItem.getName())) {
                 return Optional.of(selected);
             }
             selected++;

--- a/src/test/java/net/kemitix/ldapmanager/ldap/events/CurrentContainerChangedEventIT.java
+++ b/src/test/java/net/kemitix/ldapmanager/ldap/events/CurrentContainerChangedEventIT.java
@@ -105,8 +105,10 @@ public class CurrentContainerChangedEventIT {
     public void shouldLoadContainerObjects() throws InterruptedException {
         //given
         val ou = OU.builder()
+                   .ou("users")
                    .build();
         val user = User.builder()
+                       .cn("bob")
                        .build();
         given(ldapTemplate.find(anyObject(), eq(OU.class))).willReturn(Collections.singletonList(ou));
         given(ldapTemplate.find(anyObject(), eq(User.class))).willReturn(Collections.singletonList(user));

--- a/src/test/java/net/kemitix/ldapmanager/navigation/OuNavigationItemTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/navigation/OuNavigationItemTest.java
@@ -58,7 +58,7 @@ public class OuNavigationItemTest {
     }
 
     @Test
-    public void toStringIsName() throws Exception {
-        assertThat(ouNavigationItem.toString()).isEqualTo(name);
+    public void toStringContainsName() throws Exception {
+        assertThat(ouNavigationItem.toString()).contains(name);
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/navigation/UserNavigationItemTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/navigation/UserNavigationItemTest.java
@@ -58,7 +58,7 @@ public class UserNavigationItemTest {
     }
 
     @Test
-    public void toStringIsName() throws Exception {
-        assertThat(userNavigationItem.toString()).isEqualTo(name);
+    public void toStringContainsName() throws Exception {
+        assertThat(userNavigationItem.toString()).contains(name);
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/navigation/ui/DefaultNavigationItemActionListBoxTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/navigation/ui/DefaultNavigationItemActionListBoxTest.java
@@ -5,6 +5,8 @@ import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
 import lombok.val;
 import net.kemitix.ldapmanager.Messages;
+import net.kemitix.ldapmanager.domain.OU;
+import net.kemitix.ldapmanager.domain.User;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemSelectionChangedEvent;
 import net.kemitix.ldapmanager.ui.StartupExceptionsCollector;
@@ -296,6 +298,25 @@ public class DefaultNavigationItemActionListBoxTest {
         final NavigationItemSelectionChangedEvent event = eventCaptor.getValue();
         assertThat(event.getOldItem()).isEmpty();
         assertThat(event.getNewItem()).isEmpty();
+    }
+
+    @SuppressWarnings("ObjectToString")
+    @Test
+    public void shouldShowOusWithBraces() {
+        //given
+        val ou = OU.builder()
+                   .ou("users")
+                   .build()
+                   .asNavigationItem(applicationEventPublisher);
+        val user = User.builder()
+                       .cn("bob")
+                       .build()
+                       .asNavigationItem(applicationEventPublisher);
+        //then
+        assertThat(ou.toString()).isEqualTo("[users]");
+        assertThat(user.toString()).isEqualTo(" bob ");
+        assertThat(ou.getName()).isEqualTo("users");
+        assertThat(user.getName()).isEqualTo("bob");
     }
 
     private void givenPopulatedList() {

--- a/src/test/java/net/kemitix/ldapmanager/ui/ChangeSelectionInNavigationPanelIT.java
+++ b/src/test/java/net/kemitix/ldapmanager/ui/ChangeSelectionInNavigationPanelIT.java
@@ -79,7 +79,7 @@ public class ChangeSelectionInNavigationPanelIT extends AbstractLdapConnectionIn
                                                              .containsExactly(OU_NAME, USER_NAME);
         assertThat(navigationItemActionListBox.getSelectedIndex()).isEqualTo(0);
         assertThat(navigationItemActionListBox.getSelectedItem()
-                                              .toString()).isEqualTo(OU_NAME);
+                                              .getName()).isEqualTo(OU_NAME);
     }
 
     @Test


### PR DESCRIPTION
The underlying ActionListBox doesn't provide a means to extract the labels used to display the items added, so can only test the toString method used to set the label.