### PR TITLE
Add FeatureSet to enumerate capabilities

### DIFF
--- a/src/main/java/net/kemitix/ldapmanager/actions/user/password/ChangePasswordMenuItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/actions/user/password/ChangePasswordMenuItem.java
@@ -24,7 +24,7 @@ SOFTWARE.
 
 package net.kemitix.ldapmanager.actions.user.password;
 
-import net.kemitix.ldapmanager.context.MenuItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItem;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
 
 /**

--- a/src/main/java/net/kemitix/ldapmanager/actions/user/rename/RenameUserKeyStrokeHandler.java
+++ b/src/main/java/net/kemitix/ldapmanager/actions/user/rename/RenameUserKeyStrokeHandler.java
@@ -28,6 +28,7 @@ import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
 import lombok.Getter;
 import lombok.val;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.User;
 import net.kemitix.ldapmanager.events.KeyStrokeHandlerUpdateEvent;
 import net.kemitix.ldapmanager.handlers.KeyStrokeHandler;
@@ -135,6 +136,9 @@ class RenameUserKeyStrokeHandler implements KeyStrokeHandler {
     @EventListener(NavigationItemSelectionChangedEvent.class)
     public final void onSelectionChanged(final NavigationItemSelectionChangedEvent event) {
         active = false;
-        applicationEventPublisher.publishEvent(KeyStrokeHandlerUpdateEvent.of(this));
+        event.getNewItem()
+             .filter(navigationItem -> navigationItem instanceof UserNavigationItem)
+             .filter(navigationItem -> navigationItem.hasFeature(Features.RENAME))
+             .ifPresent(navigationItem -> active = true);
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/domain/FeatureSet.java
+++ b/src/main/java/net/kemitix/ldapmanager/domain/FeatureSet.java
@@ -22,33 +22,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.actions.user.password;
-
-import lombok.val;
-import net.kemitix.ldapmanager.domain.Features;
-import net.kemitix.ldapmanager.navigation.NavigationItem;
-import net.kemitix.ldapmanager.popupmenus.MenuItem;
-import net.kemitix.ldapmanager.popupmenus.MenuItemFactory;
-import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.stream.Stream;
+package net.kemitix.ldapmanager.domain;
 
 /**
- * Factory for creating {@link MenuItem}s to change the password of
- * {@link net.kemitix.ldapmanager.navigation.UserNavigationItem}s.
+ * Represents a set of features.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-@Component
-class ChangePasswordMenuItemFactory implements MenuItemFactory {
+public interface FeatureSet {
 
-    @Override
-    public final Stream<MenuItem> create(final NavigationItem navigationItem) {
-        val items = new ArrayList<MenuItem>();
-        if (navigationItem.hasFeature(Features.PASSWORD)) {
-            items.add(new ChangePasswordMenuItem(navigationItem));
-        }
-        return items.stream();
-    }
+    /**
+     * Checks if a feature is present.
+     *
+     * @param feature The Feature to check for.
+     *
+     * @return true if the feature is present, otherwise false.
+     */
+    boolean hasFeature(Features feature);
+
+    /**
+     * Removes the feature from the feature set.
+     *
+     * @param feature The feature to remove.
+     */
+    void removeFeature(Features feature);
 }

--- a/src/main/java/net/kemitix/ldapmanager/domain/Features.java
+++ b/src/main/java/net/kemitix/ldapmanager/domain/Features.java
@@ -22,33 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.actions.user.password;
-
-import lombok.val;
-import net.kemitix.ldapmanager.domain.Features;
-import net.kemitix.ldapmanager.navigation.NavigationItem;
-import net.kemitix.ldapmanager.popupmenus.MenuItem;
-import net.kemitix.ldapmanager.popupmenus.MenuItemFactory;
-import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.stream.Stream;
+package net.kemitix.ldapmanager.domain;
 
 /**
- * Factory for creating {@link MenuItem}s to change the password of
- * {@link net.kemitix.ldapmanager.navigation.UserNavigationItem}s.
+ * Set of features that an LdapEntity may possess.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-@Component
-class ChangePasswordMenuItemFactory implements MenuItemFactory {
+public enum Features {
 
-    @Override
-    public final Stream<MenuItem> create(final NavigationItem navigationItem) {
-        val items = new ArrayList<MenuItem>();
-        if (navigationItem.hasFeature(Features.PASSWORD)) {
-            items.add(new ChangePasswordMenuItem(navigationItem));
-        }
-        return items.stream();
-    }
+    PASSWORD,
+    RENAME
 }

--- a/src/main/java/net/kemitix/ldapmanager/domain/LdapEntity.java
+++ b/src/main/java/net/kemitix/ldapmanager/domain/LdapEntity.java
@@ -34,7 +34,7 @@ import javax.naming.Name;
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public interface LdapEntity {
+public interface LdapEntity extends FeatureSet {
 
     /**
      * Returns the name of an entity.

--- a/src/main/java/net/kemitix/ldapmanager/domain/OU.java
+++ b/src/main/java/net/kemitix/ldapmanager/domain/OU.java
@@ -36,8 +36,11 @@ import net.kemitix.ldapmanager.navigation.NavigationItemFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
+import org.springframework.ldap.odm.annotations.Transient;
 
 import javax.naming.Name;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -58,6 +61,9 @@ public final class OU implements LdapEntity {
 
     private String ou;
 
+    @Transient
+    private final Set<Features> featureSet = EnumSet.of(Features.RENAME);
+
     @Override
     public String name() {
         log.log(Level.FINEST, "name(): %1", ou);
@@ -67,5 +73,15 @@ public final class OU implements LdapEntity {
     @Override
     public NavigationItem asNavigationItem(final ApplicationEventPublisher eventPublisher) {
         return NavigationItemFactory.create(this, eventPublisher);
+    }
+
+    @Override
+    public boolean hasFeature(final Features feature) {
+        return featureSet.contains(feature);
+    }
+
+    @Override
+    public void removeFeature(final Features feature) {
+        featureSet.remove(feature);
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/domain/User.java
+++ b/src/main/java/net/kemitix/ldapmanager/domain/User.java
@@ -36,8 +36,11 @@ import net.kemitix.ldapmanager.navigation.NavigationItemFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.annotations.Id;
+import org.springframework.ldap.odm.annotations.Transient;
 
 import javax.naming.Name;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.logging.Level;
 
 /**
@@ -62,6 +65,9 @@ public final class User implements LdapEntity {
 
     private String sn;
 
+    @Transient
+    private final Set<Features> featureSet = EnumSet.of(Features.PASSWORD, Features.RENAME);
+
     @Override
     public String name() {
         log.log(Level.FINEST, "name(): %1", cn);
@@ -71,5 +77,15 @@ public final class User implements LdapEntity {
     @Override
     public NavigationItem asNavigationItem(final ApplicationEventPublisher eventPublisher) {
         return NavigationItemFactory.create(this, eventPublisher);
+    }
+
+    @Override
+    public boolean hasFeature(final Features feature) {
+        return featureSet.contains(feature);
+    }
+
+    @Override
+    public void removeFeature(final Features feature) {
+        featureSet.remove(feature);
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/navigation/NavigationItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/NavigationItem.java
@@ -24,12 +24,14 @@ SOFTWARE.
 
 package net.kemitix.ldapmanager.navigation;
 
+import net.kemitix.ldapmanager.domain.FeatureSet;
+
 /**
  * Item that can appear on the Navigation panel.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public interface NavigationItem extends Runnable, Comparable<NavigationItem> {
+public interface NavigationItem extends Runnable, Comparable<NavigationItem>, FeatureSet {
 
     /**
      * Return the name of the item.

--- a/src/main/java/net/kemitix/ldapmanager/navigation/NavigationItemsSupplier.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/NavigationItemsSupplier.java
@@ -26,6 +26,7 @@ package net.kemitix.ldapmanager.navigation;
 
 import lombok.extern.java.Log;
 import lombok.val;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.LdapEntity;
 import net.kemitix.ldapmanager.domain.OU;
 import net.kemitix.ldapmanager.ldap.LdapNameUtil;
@@ -103,10 +104,11 @@ class NavigationItemsSupplier implements Supplier<List<NavigationItem>> {
     }
 
     private NavigationItem createParentNavigationItem(final Name parentDn) {
-        return OU.builder()
-                 .dn(parentDn)
-                 .ou(PARENT)
-                 .build()
-                 .asNavigationItem(applicationEventPublisher);
+        val ou = OU.builder()
+                   .dn(parentDn)
+                   .ou(PARENT)
+                   .build();
+        ou.removeFeature(Features.RENAME);
+        return ou.asNavigationItem(applicationEventPublisher);
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/navigation/OuNavigationItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/OuNavigationItem.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
 import lombok.extern.java.Log;
 import net.kemitix.ldapmanager.Messages;
 import net.kemitix.ldapmanager.actions.ou.rename.RenameOuRequestEvent;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.OU;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemOuActionEvent;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemOuSelectedEvent;
@@ -103,5 +104,15 @@ public final class OuNavigationItem extends AbstractNavigationItem {
     @Override
     public void publishChangePasswordRequest() {
         // does not support passwords
+    }
+
+    @Override
+    public boolean hasFeature(final Features feature) {
+        return ou.hasFeature(feature);
+    }
+
+    @Override
+    public void removeFeature(final Features feature) {
+        ou.removeFeature(feature);
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/navigation/UserNavigationItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/navigation/UserNavigationItem.java
@@ -30,6 +30,7 @@ import lombok.extern.java.Log;
 import net.kemitix.ldapmanager.Messages;
 import net.kemitix.ldapmanager.actions.user.password.ChangePasswordRequestEvent;
 import net.kemitix.ldapmanager.actions.user.rename.RenameUserRequestEvent;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.User;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemUserActionEvent;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemUserSelectedEvent;
@@ -105,5 +106,15 @@ public final class UserNavigationItem extends AbstractNavigationItem {
     public void publishChangePasswordRequest() {
         log.log(Level.FINEST, "publishChangePasswordRequest(): %1", getName());
         applicationEventPublisher.publishEvent(ChangePasswordRequestEvent.create(this));
+    }
+
+    @Override
+    public boolean hasFeature(final Features feature) {
+        return user.hasFeature(feature);
+    }
+
+    @Override
+    public void removeFeature(final Features feature) {
+        user.removeFeature(feature);
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/MenuItem.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/MenuItem.java
@@ -22,26 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
-
-import net.kemitix.ldapmanager.navigation.NavigationItem;
-
-import java.util.stream.Stream;
+package net.kemitix.ldapmanager.popupmenus;
 
 /**
- * Factory for creating {@link MenuItem}s from {@link NavigationItem}s.
+ * Interface for actions that appear in context menu.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-@FunctionalInterface
-public interface MenuItemFactory {
+public interface MenuItem {
 
     /**
-     * Create any {@link MenuItem}s for the {@link NavigationItem}.
+     * Returns the label.
      *
-     * @param navigationItem The Navigation Item to create MenuItems for.
-     *
-     * @return a stream of MenuItems, may be empty.
+     * @return the label.
      */
-    Stream<MenuItem> create(NavigationItem navigationItem);
+    String getLabel();
+
+    /**
+     * Returns the runnable action to perform.
+     *
+     * @return the action
+     */
+    Runnable getAction();
 }

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/MenuItemFactory.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/MenuItemFactory.java
@@ -22,26 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.actions.user.password;
+package net.kemitix.ldapmanager.popupmenus;
 
-import net.kemitix.ldapmanager.popupmenus.MenuItem;
-import net.kemitix.ldapmanager.popupmenus.MenuItemFactory;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
-import org.springframework.stereotype.Component;
 
 import java.util.stream.Stream;
 
 /**
- * Factory for creating {@link MenuItem}s to change the password of
- * {@link net.kemitix.ldapmanager.navigation.UserNavigationItem}s.
+ * Factory for creating {@link MenuItem}s from {@link NavigationItem}s.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-@Component
-class ChangePasswordMenuItemFactory implements MenuItemFactory {
+@FunctionalInterface
+public interface MenuItemFactory {
 
-    @Override
-    public final Stream<MenuItem> create(final NavigationItem navigationItem) {
-        return Stream.of(new ChangePasswordMenuItem(navigationItem));
-    }
+    /**
+     * Create any {@link MenuItem}s for the {@link NavigationItem}.
+     *
+     * @param navigationItem The Navigation Item to create MenuItems for.
+     *
+     * @return a stream of MenuItems, may be empty.
+     */
+    Stream<MenuItem> create(NavigationItem navigationItem);
 }

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/PopupMenu.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/PopupMenu.java
@@ -22,47 +22,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus;
 
 import net.kemitix.ldapmanager.navigation.NavigationItem;
-import org.springframework.stereotype.Component;
-
-import java.util.stream.Stream;
 
 /**
- * Factory for creating {@link MenuItem}s to rename {@link NavigationItem}s.
+ * .
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-@Component
-class RenameMenuItemFactory implements MenuItemFactory {
-
-    @Override
-    public final Stream<MenuItem> create(final NavigationItem navigationItem) {
-        return Stream.of(new RenameMenuItemFactory.RenameMenuItem(navigationItem));
-    }
+public interface PopupMenu {
 
     /**
-     * Menu item for renaming a Navigation Item.
+     * Display a popup context menu for the {@link NavigationItem}.
+     *
+     * @param navigationItem The Navigation Item to display menu for.
      */
-    private static class RenameMenuItem implements MenuItem {
-
-        private static final String LABEL = "Rename";
-
-        private final NavigationItem navigationItem;
-
-        RenameMenuItem(final NavigationItem navigationItem) {
-            this.navigationItem = navigationItem;
-        }
-
-        @Override
-        public final String getLabel() {
-            return LABEL;
-        }
-
-        @Override
-        public final Runnable getAction() {
-            return navigationItem::publishRenameRequest;
-        }
-    }
+    void display(NavigationItem navigationItem);
 }

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/context/ContextKeyStrokeHandler.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/context/ContextKeyStrokeHandler.java
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/context/ContextMenu.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/context/ContextMenu.java
@@ -22,11 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
 import com.googlecode.lanterna.gui2.WindowBasedTextGUI;
 import lombok.val;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItemFactory;
+import net.kemitix.ldapmanager.popupmenus.PopupMenu;
 import net.kemitix.ldapmanager.ui.ActionListDialogBuilderFactory;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -35,12 +37,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * .
+ * The Default Context Menu for Navigation Items.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
 @Component
-class DefaultContextMenu implements ContextMenu {
+class ContextMenu implements PopupMenu {
 
     private final WindowBasedTextGUI gui;
 
@@ -55,10 +57,10 @@ class DefaultContextMenu implements ContextMenu {
      * @param dialogBuilderFactory The Action List Dialog Builder Factory.
      * @param menuItemFactories    The Factories for creating menu items.
      */
-    DefaultContextMenu(
+    ContextMenu(
             final WindowBasedTextGUI gui, final ActionListDialogBuilderFactory dialogBuilderFactory,
             final Set<MenuItemFactory> menuItemFactories
-                      ) {
+               ) {
         this.gui = gui;
         this.dialogBuilderFactory = dialogBuilderFactory;
         this.menuItemFactories = new HashSet<>(menuItemFactories);

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/context/DisplayContextMenuEvent.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/context/DisplayContextMenuEvent.java
@@ -22,8 +22,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/**
- * Context menu popup.
- */
+package net.kemitix.ldapmanager.popupmenus.context;
 
-package net.kemitix.ldapmanager.context;
+import lombok.Getter;
+import net.kemitix.ldapmanager.navigation.NavigationItem;
+
+/**
+ * Raised when a context menu is wanted for a {@link NavigationItem}.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public final class DisplayContextMenuEvent {
+
+    @Getter
+    private final NavigationItem navigationItem;
+
+    private DisplayContextMenuEvent(final NavigationItem navigationItem) {
+        this.navigationItem = navigationItem;
+    }
+
+    /**
+     * Create a new DisplayContextMenuEvent.
+     *
+     * @param navigationItem The Navigation Item to display the context menu for.
+     *
+     * @return the event
+     */
+    public static DisplayContextMenuEvent of(final NavigationItem navigationItem) {
+        return new DisplayContextMenuEvent(navigationItem);
+    }
+}

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/context/RenameMenuItemFactory.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/context/RenameMenuItemFactory.java
@@ -22,33 +22,49 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
-import lombok.Getter;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItemFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
 
 /**
- * Raised when a context menu is wanted for a {@link NavigationItem}.
+ * Factory for creating {@link MenuItem}s to rename {@link NavigationItem}s.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public final class DisplayContextMenuEvent {
+@Component
+class RenameMenuItemFactory implements MenuItemFactory {
 
-    @Getter
-    private final NavigationItem navigationItem;
-
-    private DisplayContextMenuEvent(final NavigationItem navigationItem) {
-        this.navigationItem = navigationItem;
+    @Override
+    public final Stream<MenuItem> create(final NavigationItem navigationItem) {
+        return Stream.of(new RenameMenuItemFactory.RenameMenuItem(navigationItem));
     }
 
     /**
-     * Create a new DisplayContextMenuEvent.
-     *
-     * @param navigationItem The Navigation Item to display the context menu for.
-     *
-     * @return the event
+     * Menu item for renaming a Navigation Item.
      */
-    public static DisplayContextMenuEvent of(final NavigationItem navigationItem) {
-        return new DisplayContextMenuEvent(navigationItem);
+    private static class RenameMenuItem implements MenuItem {
+
+        private static final String LABEL = "Rename";
+
+        private final NavigationItem navigationItem;
+
+        RenameMenuItem(final NavigationItem navigationItem) {
+            this.navigationItem = navigationItem;
+        }
+
+        @Override
+        public final String getLabel() {
+            return LABEL;
+        }
+
+        @Override
+        public final Runnable getAction() {
+            return navigationItem::publishRenameRequest;
+        }
     }
 }

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/context/package-info.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/context/package-info.java
@@ -22,21 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
-
-import net.kemitix.ldapmanager.navigation.NavigationItem;
-
 /**
- * .
- *
- * @author Paul Campbell (pcampbell@kemitix.net)
+ * Context menu popup.
  */
-public interface ContextMenu {
 
-    /**
-     * Display a popup context menu for the {@link NavigationItem}.
-     *
-     * @param navigationItem The Navigation Item to display menu for.
-     */
-    void display(NavigationItem navigationItem);
-}
+package net.kemitix.ldapmanager.popupmenus.context;

--- a/src/main/java/net/kemitix/ldapmanager/popupmenus/package-info.java
+++ b/src/main/java/net/kemitix/ldapmanager/popupmenus/package-info.java
@@ -22,26 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-package net.kemitix.ldapmanager.context;
-
 /**
- * Interface for actions that appear in context menu.
- *
- * @author Paul Campbell (pcampbell@kemitix.net)
+ * Popup menus.
  */
-public interface MenuItem {
 
-    /**
-     * Returns the label.
-     *
-     * @return the label.
-     */
-    String getLabel();
-
-    /**
-     * Returns the runnable action to perform.
-     *
-     * @return the action
-     */
-    Runnable getAction();
-}
+package net.kemitix.ldapmanager.popupmenus;

--- a/src/test/java/net/kemitix/ldapmanager/actions/user/password/ChangePasswordMenuItemFactoryTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/actions/user/password/ChangePasswordMenuItemFactoryTest.java
@@ -1,12 +1,15 @@
 package net.kemitix.ldapmanager.actions.user.password;
 
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 /**
  * .
@@ -27,13 +30,28 @@ public class ChangePasswordMenuItemFactoryTest {
     }
 
     @Test
-    public void shouldCreateWithActionThatPublishedOnNavigationItem() throws Exception {
+    public void whenNavigationItemHasPasswordFeatureThenPublishChangeRequest() throws Exception {
+        //given
+        given(navigationItem.hasFeature(Features.PASSWORD)).willReturn(true);
         //when
         factory.create(navigationItem)
                .forEach(menuItem -> menuItem.getAction()
                                             .run());
         //then
         then(navigationItem).should()
+                            .publishChangePasswordRequest();
+    }
+
+    @Test
+    public void whenNavigationItemHasNoPasswordFeatureThenDoNotPublishChangeRequest() throws Exception {
+        //given
+        given(navigationItem.hasFeature(Features.PASSWORD)).willReturn(false);
+        //when
+        factory.create(navigationItem)
+               .forEach(menuItem -> menuItem.getAction()
+                                            .run());
+        //then
+        then(navigationItem).should(never())
                             .publishChangePasswordRequest();
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/domain/OUTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/domain/OUTest.java
@@ -51,11 +51,29 @@ public class OUTest {
     @Test
     public void shouldGetOuForName() {
         //given
-        val user = OU.builder()
-                     .dn(LdapNameUtil.parse("ou=name"))
-                     .ou("name")
-                     .build();
+        val ou = OU.builder()
+                   .dn(LdapNameUtil.parse("ou=name"))
+                   .ou("name")
+                   .build();
         //then
-        assertThat(user.name()).isEqualTo("name");
+        assertThat(ou.name()).isEqualTo("name");
+    }
+
+    @Test
+    public void shouldHaveFeatureRename() {
+        //given
+        val ou = OU.builder()
+                   .build();
+        //then
+        assertThat(ou.hasFeature(Features.RENAME)).isTrue();
+    }
+
+    @Test
+    public void shouldNotHaveFeaturePassword() {
+        //given
+        val ou = OU.builder()
+                   .build();
+        //then
+        assertThat(ou.hasFeature(Features.PASSWORD)).isFalse();
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/domain/UserTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/domain/UserTest.java
@@ -64,4 +64,22 @@ public class UserTest {
         //then
         assertThat(user.name()).isEqualTo("name");
     }
+
+    @Test
+    public void shouldHaveFeatureRename() {
+        //given
+        val user = User.builder()
+                       .build();
+        //then
+        assertThat(user.hasFeature(Features.RENAME)).isTrue();
+    }
+
+    @Test
+    public void shouldHaveFeaturePassword() {
+        //given
+        val user = User.builder()
+                       .build();
+        //then
+        assertThat(user.hasFeature(Features.PASSWORD)).isTrue();
+    }
 }

--- a/src/test/java/net/kemitix/ldapmanager/navigation/OuNavigationItemTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/navigation/OuNavigationItemTest.java
@@ -2,6 +2,7 @@ package net.kemitix.ldapmanager.navigation;
 
 import net.kemitix.ldapmanager.actions.ou.rename.RenameOuRequestEvent;
 import net.kemitix.ldapmanager.actions.user.password.ChangePasswordRequestEvent;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.OU;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemOuSelectedEvent;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemUserSelectedEvent;
@@ -115,5 +116,15 @@ public class OuNavigationItemTest {
         //then
         then(applicationEventPublisher).should(never())
                                        .publishEvent(any(ChangePasswordRequestEvent.class));
+    }
+
+    @Test
+    public void shouldHaveFeatureRename() {
+        assertThat(ouNavigationItem.hasFeature(Features.RENAME)).isTrue();
+    }
+
+    @Test
+    public void shouldNotHaveFeaturePassword() {
+        assertThat(ouNavigationItem.hasFeature(Features.PASSWORD)).isFalse();
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/navigation/UserNavigationItemTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/navigation/UserNavigationItemTest.java
@@ -2,6 +2,7 @@ package net.kemitix.ldapmanager.navigation;
 
 import net.kemitix.ldapmanager.actions.user.password.ChangePasswordRequestEvent;
 import net.kemitix.ldapmanager.actions.user.rename.RenameUserRequestEvent;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.User;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemUserActionEvent;
 import net.kemitix.ldapmanager.navigation.events.NavigationItemUserSelectedEvent;
@@ -113,5 +114,15 @@ public class UserNavigationItemTest {
         //then
         then(applicationEventPublisher).should()
                                        .publishEvent(any(ChangePasswordRequestEvent.class));
+    }
+
+    @Test
+    public void shouldHaveFeatureRename() {
+        assertThat(userNavigationItem.hasFeature(Features.RENAME)).isTrue();
+    }
+
+    @Test
+    public void shouldHaveFeaturePassword() {
+        assertThat(userNavigationItem.hasFeature(Features.PASSWORD)).isTrue();
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/navigation/ui/DefaultNavigationItemActionListBoxTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/navigation/ui/DefaultNavigationItemActionListBoxTest.java
@@ -5,6 +5,7 @@ import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;
 import lombok.val;
 import net.kemitix.ldapmanager.Messages;
+import net.kemitix.ldapmanager.domain.Features;
 import net.kemitix.ldapmanager.domain.OU;
 import net.kemitix.ldapmanager.domain.User;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
@@ -385,6 +386,16 @@ public class DefaultNavigationItemActionListBoxTest {
         @Override
         public void publishChangePasswordRequest() {
             applicationEventPublisher.publishEvent(this);
+        }
+
+        @Override
+        public boolean hasFeature(final Features feature) {
+            return false;
+        }
+
+        @Override
+        public void removeFeature(final Features feature) {
+
         }
     }
 }

--- a/src/test/java/net/kemitix/ldapmanager/popupmenus/context/ContextKeyStrokeHandlerTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/popupmenus/context/ContextKeyStrokeHandlerTest.java
@@ -1,4 +1,4 @@
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
 import com.googlecode.lanterna.input.KeyStroke;
 import com.googlecode.lanterna.input.KeyType;

--- a/src/test/java/net/kemitix/ldapmanager/popupmenus/context/ContextMenuTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/popupmenus/context/ContextMenuTest.java
@@ -1,9 +1,12 @@
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
 import com.googlecode.lanterna.gui2.WindowBasedTextGUI;
 import com.googlecode.lanterna.gui2.dialogs.ActionListDialogBuilder;
 import lombok.val;
 import net.kemitix.ldapmanager.navigation.NavigationItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItemFactory;
+import net.kemitix.ldapmanager.popupmenus.PopupMenu;
 import net.kemitix.ldapmanager.ui.ActionListDialogBuilderFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,13 +22,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 /**
- * Tests for {@link DefaultContextMenu}.
+ * Tests for {@link PopupMenu}.
  *
  * @author Paul Campbell (pcampbell@kemitix.net)
  */
-public class DefaultContextMenuTest {
+public class ContextMenuTest {
 
-    private DefaultContextMenu contextMenu;
+    private ContextMenu contextMenu;
 
     @Mock
     private WindowBasedTextGUI gui;
@@ -84,7 +87,7 @@ public class DefaultContextMenuTest {
 
     private void prepareCallToDisplay() {
         menuItemsFactories.add(menuItemFactory);
-        contextMenu = new DefaultContextMenu(gui, dialogBuilderFactory, menuItemsFactories);
+        contextMenu = new ContextMenu(gui, dialogBuilderFactory, menuItemsFactories);
 
         given(dialogBuilderFactory.create()).willReturn(actionListDialogBuilder);
         given(menuItemFactory.create(navigationItem)).willReturn(Stream.of(menuItem));

--- a/src/test/java/net/kemitix/ldapmanager/popupmenus/context/DisplayContextMenuEventTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/popupmenus/context/DisplayContextMenuEventTest.java
@@ -1,4 +1,4 @@
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
 import net.kemitix.ldapmanager.navigation.NavigationItem;
 import org.junit.Test;

--- a/src/test/java/net/kemitix/ldapmanager/popupmenus/context/RenameMenuItemFactoryTest.java
+++ b/src/test/java/net/kemitix/ldapmanager/popupmenus/context/RenameMenuItemFactoryTest.java
@@ -1,6 +1,7 @@
-package net.kemitix.ldapmanager.context;
+package net.kemitix.ldapmanager.popupmenus.context;
 
 import net.kemitix.ldapmanager.navigation.NavigationItem;
+import net.kemitix.ldapmanager.popupmenus.MenuItem;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;


### PR DESCRIPTION
Rather than continuing to add numerous `canThis()` and `canThat()` methods to `LdapEntity`, use a `Features` enum and a single `hasFeature()` method.